### PR TITLE
Use new jsonnetfmt binary

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -8,9 +8,9 @@ import { getEdits } from './diffUtils';
 export class Formatter {
   private format(data: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      const bin = 'jsonnet';
+      const bin = 'jsonnetfmt';
       // This uses the Google internal config per https://github.com/google/jsonnet/issues/359.
-      const args = ['fmt', '--indent', '2', '--max-blank-lines', '2', '--sort-imports', '--string-style', 's', '--comment-style', 's', '-'];
+      const args = ['--indent', '2', '--max-blank-lines', '2', '--sort-imports', '--string-style', 's', '--comment-style', 's', '-'];
       let p = cp.spawn(bin, args);
       let stdout_: Buffer[] = [];
       let stderr_: Buffer[] = [];


### PR DESCRIPTION
In Jsonnet 0.13 the `jsonnet fmt` command was changed to `jsonnetfmt`.  See [here](https://github.com/google/jsonnet/releases/tag/v0.13.0) for details.